### PR TITLE
fix: align flower tiles with melds

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,39 @@ import { Tile as TileType, TILE_DISPLAY, Suit } from './core/tile';
 import { canChi, canPeng, canGang, getChiOptions, getPengOption, getGangOption } from './core/meld';
 import { canWinByClaimingDiscard, checkWin } from './core/win';
 
+interface MeldAndFlowerAreaProps {
+  melds: React.ComponentProps<typeof MeldArea>['melds'];
+  flowers: TileType[];
+  flowerSize: TileSize;
+  isHuman?: boolean;
+  compact?: boolean;
+  forceReveal?: boolean;
+  className?: string;
+}
+
+const MeldAndFlowerArea: React.FC<MeldAndFlowerAreaProps> = ({
+  melds,
+  flowers,
+  flowerSize,
+  isHuman = false,
+  compact = false,
+  forceReveal = false,
+  className = '',
+}) => {
+  if (melds.length === 0 && flowers.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={`flex items-start justify-center gap-2 flex-wrap ${className}`}>
+      {melds.length > 0 && (
+        <MeldArea melds={melds} isHuman={isHuman} compact={compact} forceReveal={forceReveal} />
+      )}
+      <FlowerArea tiles={flowers} size={flowerSize} compact={compact} />
+    </div>
+  );
+};
+
 function App() {
   const {
     state,
@@ -261,14 +294,14 @@ function App() {
                   <Tile key={tile.id} tile={tile} size={effectiveTileSize} showLabel={false} />
                 ))}
               </div>
-              {state.players[2].melds.length > 0 && (
-                <div className="mt-1">
-                  <MeldArea melds={state.players[2].melds} isHuman={false} compact={true} forceReveal={true} />
-                </div>
-              )}
-              <div className="mt-1 flex justify-center">
-                <FlowerArea tiles={state.players[2].flowers} size="sm" />
-              </div>
+              <MeldAndFlowerArea
+                melds={state.players[2].melds}
+                flowers={state.players[2].flowers}
+                flowerSize="sm"
+                compact={true}
+                forceReveal={true}
+                className="mt-1"
+              />
             </div>
           </div>
 
@@ -284,14 +317,14 @@ function App() {
                   <Tile key={tile.id} tile={tile} size={effectiveTileSize} showLabel={false} />
                 ))}
               </div>
-              {state.players[3].melds.length > 0 && (
-                <div className="mt-1">
-                  <MeldArea melds={state.players[3].melds} isHuman={false} compact={true} forceReveal={true} />
-                </div>
-              )}
-              <div className="mt-1 flex justify-center">
-                <FlowerArea tiles={state.players[3].flowers} size="sm" />
-              </div>
+              <MeldAndFlowerArea
+                melds={state.players[3].melds}
+                flowers={state.players[3].flowers}
+                flowerSize="sm"
+                compact={true}
+                forceReveal={true}
+                className="mt-1"
+              />
             </div>
 
             {/* Center */}
@@ -334,27 +367,27 @@ function App() {
                   <Tile key={tile.id} tile={tile} size={effectiveTileSize} showLabel={false} />
                 ))}
               </div>
-              {state.players[1].melds.length > 0 && (
-                <div className="mt-1">
-                  <MeldArea melds={state.players[1].melds} isHuman={false} compact={true} forceReveal={true} />
-                </div>
-              )}
-              <div className="mt-1 flex justify-center">
-                <FlowerArea tiles={state.players[1].flowers} size="sm" />
-              </div>
+              <MeldAndFlowerArea
+                melds={state.players[1].melds}
+                flowers={state.players[1].flowers}
+                flowerSize="sm"
+                compact={true}
+                forceReveal={true}
+                className="mt-1"
+              />
             </div>
           </div>
 
           {/* Bottom player (Human) */}
           <div className="p-4 bg-green-900/50">
-            {humanPlayer.melds.length > 0 && (
-              <div className="mb-3 flex justify-center">
-                <MeldArea melds={humanPlayer.melds} isHuman={true} forceReveal={true} />
-              </div>
-            )}
-            <div className="mb-3 flex justify-center">
-              <FlowerArea tiles={humanPlayer.flowers} size={effectiveTileSize} />
-            </div>
+            <MeldAndFlowerArea
+              melds={humanPlayer.melds}
+              flowers={humanPlayer.flowers}
+              flowerSize="md"
+              isHuman={true}
+              forceReveal={true}
+              className="mb-3"
+            />
             <div className="text-center mb-4">
               <div className="text-white text-sm mb-2">
                 👤 你的手牌（南）— {humanPlayer.hand.length} 張
@@ -519,14 +552,13 @@ function App() {
                 <span className="text-white text-xs ml-1">+{state.players[2].hand.length - 9}</span>
               )}
             </div>
-            {state.players[2].melds.length > 0 && (
-              <div className="mt-1">
-                <MeldArea melds={state.players[2].melds} isHuman={false} compact={true} />
-              </div>
-            )}
-              <div className="mt-1 flex justify-center">
-                <FlowerArea tiles={state.players[2].flowers} size="sm" />
-              </div>
+            <MeldAndFlowerArea
+              melds={state.players[2].melds}
+              flowers={state.players[2].flowers}
+              flowerSize="sm"
+              compact={true}
+              className="mt-1"
+            />
           </div>
         </div>
 
@@ -543,14 +575,13 @@ function App() {
                 <div key={i} className="w-5 h-7 bg-blue-800 rounded-sm border border-blue-600" />
               ))}
             </div>
-            {state.players[3].melds.length > 0 && (
-              <div className="mt-1">
-                <MeldArea melds={state.players[3].melds} isHuman={false} compact={true} />
-              </div>
-            )}
-              <div className="mt-1 flex justify-center">
-                <FlowerArea tiles={state.players[3].flowers} size="sm" />
-              </div>
+            <MeldAndFlowerArea
+              melds={state.players[3].melds}
+              flowers={state.players[3].flowers}
+              flowerSize="sm"
+              compact={true}
+              className="mt-1"
+            />
           </div>
 
           {/* Center */}
@@ -585,27 +616,25 @@ function App() {
                 <div key={i} className="w-5 h-7 bg-blue-800 rounded-sm border border-blue-600" />
               ))}
             </div>
-            {state.players[1].melds.length > 0 && (
-              <div className="mt-1">
-                <MeldArea melds={state.players[1].melds} isHuman={false} compact={true} />
-              </div>
-            )}
-              <div className="mt-1 flex justify-center">
-                <FlowerArea tiles={state.players[1].flowers} size="sm" />
-              </div>
+            <MeldAndFlowerArea
+              melds={state.players[1].melds}
+              flowers={state.players[1].flowers}
+              flowerSize="sm"
+              compact={true}
+              className="mt-1"
+            />
           </div>
         </div>
 
         {/* Bottom player (Human) */}
         <div className="p-4 bg-green-900/50">
-          {humanPlayer.melds.length > 0 && (
-            <div className="mb-3 flex justify-center">
-              <MeldArea melds={humanPlayer.melds} isHuman={true} />
-            </div>
-          )}
-            <div className="mb-3 flex justify-center">
-              <FlowerArea tiles={humanPlayer.flowers} size={effectiveTileSize} />
-            </div>
+          <MeldAndFlowerArea
+            melds={humanPlayer.melds}
+            flowers={humanPlayer.flowers}
+            flowerSize="md"
+            isHuman={true}
+            className="mb-3"
+          />
           <div className="text-center mb-4">
             <div className="text-white text-sm mb-2">
               {getCurrentPlayerIndicator(0) && <span className="mr-1">{getCurrentPlayerIndicator(0)}</span>}

--- a/src/components/FlowerArea.tsx
+++ b/src/components/FlowerArea.tsx
@@ -5,20 +5,21 @@ import TileComponent, { TileSize } from './Tile';
 interface FlowerAreaProps {
   tiles: Tile[];
   size?: TileSize;
+  compact?: boolean;
 }
 
-const FlowerArea: React.FC<FlowerAreaProps> = ({ tiles, size = 'md' }) => {
-  console.log('FlowerArea receiving tiles:', tiles);
+const FlowerArea: React.FC<FlowerAreaProps> = ({ tiles, size = 'md', compact = false }) => {
   if (tiles.length === 0) {
     return null;
   }
 
   return (
-    <div className="flex items-center gap-1 mt-1 p-2 border-2 border-yellow-500 bg-black/50">
-      <span className="text-xs text-yellow-300 mr-1">花牌:</span>
-      {tiles.map((tile) => (
-        <TileComponent key={tile.id} tile={tile} size={size} showLabel={false} />
-      ))}
+    <div className={`flex flex-col items-center border-2 rounded-lg border-yellow-400 bg-yellow-50 ${compact ? 'p-1' : 'p-2'}`}>
+      <div className="flex gap-0.5">
+        {tiles.map((tile) => (
+          <TileComponent key={tile.id} tile={tile} size={size} showLabel={false} />
+        ))}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Render melds and flower tiles in a shared row for every player
- Restyle flower tiles to match meld groups while keeping a distinct yellow border
- Use md flower tile size for the human meld row so it aligns with meld tiles

## Verification
- Not run: full project build is currently blocked by existing test runner/type setup issues